### PR TITLE
Make getArraysDifference more efficient

### DIFF
--- a/utils/getArraysDifference/getArraysDifference.ts
+++ b/utils/getArraysDifference/getArraysDifference.ts
@@ -12,7 +12,8 @@ export const getArraysDifference = ({
     mainArray,
     arrayToCompareWith,
 }: getArraysDifferenceParams): unknown[] => {
+    const setToCompareWith = new Set(arrayToCompareWith);
     return mainArray.filter((i) => {
-        return !arrayToCompareWith.includes(i);
+        return !setToCompareWith.has(i);
     });
 };


### PR DESCRIPTION
`Set#has` locates the item in O(1), as opposed to `Array#include` that takes O(n) to do the same thing. This optimizes time complexity from quadratic to linear.